### PR TITLE
fullcalendar導入

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -1,2 +1,16 @@
 @import 'bootstrap/scss/bootstrap';
 @import 'bootstrap-icons/font/bootstrap-icons';
+
+@import "../../node_modules/@fullcalendar/core/index.css";
+@import "../../node_modules/@fullcalendar/daygrid/index.css";
+@import "../../node_modules/@fullcalendar/timegrid/index.css";
+
+#calendar {
+    max-width: 900px;
+    margin: 0 auto;
+    .fc-event {
+    background-color: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+}
+}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,5 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import * as bootstrap from "bootstrap"
+
+import "./calendar"

--- a/app/javascript/calendar.js
+++ b/app/javascript/calendar.js
@@ -1,0 +1,56 @@
+import { Calendar } from '@fullcalendar/core'
+import dayGridPlugin from '@fullcalendar/daygrid'
+import timeGridPlugin from '@fullcalendar/timegrid'
+import interactionPlugin from '@fullcalendar/interaction'
+import jaLocale from '@fullcalendar/core/locales/ja'
+
+document.addEventListener('turbo:load', () => {
+  const calendarEl = document.getElementById('calendar')
+  if (!calendarEl) return
+
+  const projectId = calendarEl.dataset.projectId
+
+  if (calendarEl) {
+    const calendar = new Calendar(calendarEl, {
+      plugins: [dayGridPlugin],
+      initialView: 'dayGridMonth',
+      locale: jaLocale,
+      headerToolbar: {
+        left: 'prev,next today',
+        center: 'title',
+        right: ''
+      },
+      events: [
+        {
+            title: "作成済みシフト",
+            start: "2025-09-21",
+            extendedProps: {
+                type: "created",
+                url: `/projects/${projectId}/shifts/1/pdf`
+            }
+        },
+        {
+            title: "未作成",
+            start: "2025-09-22",
+            extendedProps: {
+                type: "new",
+                url: `/projects/${projectId}/shifts/new?date=2025-09-22`
+            }
+        }
+      ],
+      eventContent: function (arg) {
+        let icon = document.createElement("i")
+        if (arg.event.extendedProps.type === "new") {
+            icon.className = "bi bi-plus-circle text-success fs-4"
+        } else {
+            icon.className = "bi bi-file-earmark-pdf text-primary fs-4"
+        }
+        let link = document.createElement("a")
+        link.href = arg.event.extendedProps.url
+        link.appendChild(icon)
+        return { domNodes: [link] }
+      }
+    })
+    calendar.render()
+  }
+})

--- a/app/views/projects/shifts/top.html.erb
+++ b/app/views/projects/shifts/top.html.erb
@@ -1,1 +1,7 @@
-<h1><%= @project.name %>シフト管理TOP</h1>
+<div class="bg-light rounded-3 p-3 mb-4 text-center shadow-sm">
+  <h1 class="h3 mb-0 text-success fw-bold"><%= @project.name %> シフト</h1>
+</div>
+<div class="d-flex justify-content-end mb-3">
+  <%= link_to "TOPへ戻る", projects_path, class: "btn btn-success" %>
+</div>
+<div id="calendar" data-project-id="<%= @project.id %>"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,5 +21,12 @@ Rails.application.routes.draw do
 
   resources :projects, only: [:index, :new, :create, :edit, :update, :destroy] do
     get 'shift_top', to: 'projects/shifts#top'
+
+    resources :shifts, only: [:new, :create, :edit, :update, :destroy] do
+      # PDF表示画面のためのURL作成
+      member do
+        get :pdf
+      end
+    end
   end
 end

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "autoprefixer": "^10.4.21",
     "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
+    "fullcalendar": "^6.1.19",
     "nodemon": "^3.1.10",
     "postcss": "^8.5.6",
     "postcss-cli": "^11.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -132,6 +132,42 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz#585624dc829cfb6e7c0aa6c3ca7d7e6daa87e34f"
   integrity sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==
 
+"@fullcalendar/core@~6.1.19":
+  version "6.1.19"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/core/-/core-6.1.19.tgz#60379111ba0cfb9fd9bc6594fee47cf855fc77b2"
+  integrity sha512-z0aVlO5e4Wah6p6mouM0UEqtRf1MZZPt4mwzEyU6kusaNL+dlWQgAasF2cK23hwT4cmxkEmr4inULXgpyeExdQ==
+  dependencies:
+    preact "~10.12.1"
+
+"@fullcalendar/daygrid@~6.1.19":
+  version "6.1.19"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/daygrid/-/daygrid-6.1.19.tgz#1d70a7f3f4cc13d3f27f55ed6880aae09a1a367b"
+  integrity sha512-IAAfnMICnVWPjpT4zi87i3FEw0xxSza0avqY/HedKEz+l5MTBYvCDPOWDATpzXoLut3aACsjktIyw9thvIcRYQ==
+
+"@fullcalendar/interaction@~6.1.19":
+  version "6.1.19"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/interaction/-/interaction-6.1.19.tgz#48d85601a4203ede7cb400323fe5a9c163e28804"
+  integrity sha512-GOciy79xe8JMVp+1evAU3ytdwN/7tv35t5i1vFkifiuWcQMLC/JnLg/RA2s4sYmQwoYhTw/p4GLcP0gO5B3X5w==
+
+"@fullcalendar/list@~6.1.19":
+  version "6.1.19"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/list/-/list-6.1.19.tgz#060bc8ee1895c172d28689475b8e567e166a9828"
+  integrity sha512-knZHpAVF0LbzZpSJSUmLUUzF0XlU/MRGK+Py2s0/mP93bCtno1k2L3XPs/kzh528hSjehwLm89RgKTSfW1P6cA==
+
+"@fullcalendar/multimonth@~6.1.19":
+  version "6.1.19"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/multimonth/-/multimonth-6.1.19.tgz#9a125ece3c2161fcabc30350a3eb9d9d985ff7c5"
+  integrity sha512-YYP8o/tjNLFRKhelwiq5ja3Jm3WDf3bfOUHf32JvAWwfotCvZjD7tYv66Nj02mQ8OWWJINa2EQGJxFHgIs14aA==
+  dependencies:
+    "@fullcalendar/daygrid" "~6.1.19"
+
+"@fullcalendar/timegrid@~6.1.19":
+  version "6.1.19"
+  resolved "https://registry.yarnpkg.com/@fullcalendar/timegrid/-/timegrid-6.1.19.tgz#bb4b2e3039c995b61284ee5b76ad9dcc696b71ce"
+  integrity sha512-OuzpUueyO9wB5OZ8rs7TWIoqvu4v3yEqdDxZ2VcsMldCpYJRiOe7yHWKr4ap5Tb0fs7Rjbserc/b6Nt7ol6BRg==
+  dependencies:
+    "@fullcalendar/daygrid" "~6.1.19"
+
 "@hotwired/stimulus@^3.2.2":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.2.tgz#071aab59c600fed95b97939e605ff261a4251608"
@@ -479,6 +515,18 @@ fsevents@~2.3.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
+fullcalendar@^6.1.19:
+  version "6.1.19"
+  resolved "https://registry.yarnpkg.com/fullcalendar/-/fullcalendar-6.1.19.tgz#e43bdd0c21a7e18f897ece4006d1b0b4d29b5e39"
+  integrity sha512-/DsMLYyU1kdOVojaV+ITNH2cHlHtyt6X3m4P6hhH0kwfHZpQbXajJnDbnFIufu/BdE9YcknMRPJj3R7FbPkg1A==
+  dependencies:
+    "@fullcalendar/core" "~6.1.19"
+    "@fullcalendar/daygrid" "~6.1.19"
+    "@fullcalendar/interaction" "~6.1.19"
+    "@fullcalendar/list" "~6.1.19"
+    "@fullcalendar/multimonth" "~6.1.19"
+    "@fullcalendar/timegrid" "~6.1.19"
+
 get-caller-file@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
@@ -681,6 +729,11 @@ postcss@^8.5.6:
     nanoid "^3.3.11"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
+
+preact@~10.12.1:
+  version "10.12.1"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.12.1.tgz#8f9cb5442f560e532729b7d23d42fd1161354a21"
+  integrity sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==
 
 pretty-hrtime@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
fullcalendarを導入しシフト作成TOP画面に表示させた
- application.jsにシフトデザインの枠組みを表記
- application.bootstrap.scss に@import
- docker compose exec web yarn build :cssでビルド実行
- 試作としてシフト未作成と作成済のイベントを記載し
  - 作成済→PDFicon
  - 未作成→新規作成アイコン　を導入した
  