### PR TITLE
手動編集機能実装

### DIFF
--- a/app/controllers/shift_details_controller.rb
+++ b/app/controllers/shift_details_controller.rb
@@ -1,0 +1,60 @@
+class ShiftDetailsController < ApplicationController
+  before_action :set_shift_detail
+
+  def update
+    attrs = shift_detail_params.to_h
+
+    if attrs["rest_start_time"].present?
+      attrs["rest_start_time"] = build_time(attrs["rest_start_time"].to_i)
+    end
+
+    if attrs["rest_end_time"].present?
+      attrs["rest_end_time"] = build_time(attrs["rest_end_time"].to_i)
+    end
+
+    if @shift_detail.update(attrs)
+      render json: { success: true, detail: to_detail_json(@shift_detail) }
+    else
+      # DBの正しい状態に戻す
+      @shift_detail.reload
+      render json: {
+        success: false,
+        errors: @shift_detail.errors.full_messages,
+        detail: to_detail_json(@shift_detail)
+      }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_shift_detail
+    @shift_detail = ShiftDetail.find(params[:id])
+  end
+
+  def shift_detail_params
+    params.require(:shift_detail).permit(:rest_start_time, :rest_end_time, :break_room_id)
+  end
+
+  # "26" → 翌日の 2:00 に変換
+  def build_time(hour_value)
+    base_date = @shift_detail.shift.shift_date
+    hour = hour_value % 24       # 25 → 1
+    day_offset = hour_value / 24 # 25 → 1
+    Time.zone.local(base_date.year, base_date.month, base_date.day, hour) + day_offset.days
+  end
+
+  def to_detail_json(detail)
+    {
+      id: detail.id,
+      rest_start_time: (18..33).find do |h|
+        detail.rest_start_time.hour == (h % 24) &&
+        (h >= 24) == (detail.rest_start_time.to_date > detail.shift.shift_date)
+      end,
+      rest_end_time: (18..33).find do |h|
+        detail.rest_end_time.hour == (h % 24) &&
+        (h >= 24) == (detail.rest_end_time.to_date > detail.shift.shift_date)
+      end,
+      break_room_id: detail.break_room_id
+    }
+  end
+end

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -71,6 +71,7 @@ class ShiftsController < ApplicationController
   def show
     @shift = @project.shifts.find(params[:id])
     @shift_details = @shift.shift_details.includes(:staff, :break_room)
+    @break_rooms = @project.break_rooms
   end
 
   def confirm

--- a/app/helpers/shift_details_helper.rb
+++ b/app/helpers/shift_details_helper.rb
@@ -1,0 +1,2 @@
+module ShiftDetailsHelper
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,6 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+import ShiftDetailController from "./shift_detail_controller"
+application.register("shift-detail", ShiftDetailController)

--- a/app/javascript/controllers/shift_detail_controller.js
+++ b/app/javascript/controllers/shift_detail_controller.js
@@ -1,0 +1,65 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  update(event) {
+    const select = event.target
+    const id = select.dataset.shiftDetailId
+    const field = select.dataset.field
+    const value = select.value
+
+    // 前回の値を保存（必ず変更前を記録する）
+    if (!select.dataset.previousValue) {
+      select.dataset.previousValue = value
+    }
+
+    fetch(`/shift_details/${id}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
+      },
+      body: JSON.stringify({ shift_detail: { [field]: value } })
+    })
+      .then(res => res.json())
+      .then(data => {
+        if (data.success) {
+          // 成功 → 今回の値を新しい previousValue として保存
+          select.dataset.previousValue = value
+          this.refreshRow(data.detail)
+        } else {
+          // 失敗 → アラート表示 & 前の値に戻す
+          alert("更新に失敗しました: " + data.errors.join(", "))
+
+          // セレクトを前の状態に戻す
+          select.value = select.dataset.previousValue
+
+          // 色はDB側の状態（detail）でリフレッシュ
+          if (data.detail) {
+            this.refreshRow(data.detail)
+          }
+        }
+      })
+      .catch(() => {
+        alert("通信エラーが発生しました。")
+        select.value = select.dataset.previousValue
+      })
+  }
+
+  refreshRow(detail) {
+    const row = document.querySelector(`tr[data-shift-detail-id="${detail.id}"]`)
+    if (!row) return
+
+    // リセット
+    row.querySelectorAll("td.time-cell").forEach(td => td.classList.remove("bg-info"))
+
+    const start = parseInt(detail.rest_start_time, 10)
+    const end   = parseInt(detail.rest_end_time, 10)
+
+    row.querySelectorAll("td.time-cell").forEach(td => {
+      const cellHour = parseInt(td.dataset.hour, 10)
+      if (cellHour >= start && cellHour < end) {
+        td.classList.add("bg-info")
+      }
+    })
+  }
+}

--- a/app/models/shift_detail.rb
+++ b/app/models/shift_detail.rb
@@ -11,7 +11,9 @@ class ShiftDetail < ApplicationRecord
   private
 
   def rest_time_order
-    if rest_start_time.present? && rest_end_time.present? && rest_start_time >= rest_end_time
+    return if rest_start_time.blank? || rest_end_time.blank?
+
+    if rest_end_time <= rest_start_time
       errors.add(:rest_end_time, "は開始時間より後にしてください")
     end
   end

--- a/app/views/shift_details/update.html.erb
+++ b/app/views/shift_details/update.html.erb
@@ -1,0 +1,2 @@
+<h1>ShiftDetails#update</h1>
+<p>Find me in app/views/shift_details/update.html.erb</p>

--- a/app/views/shifts/show.html.erb
+++ b/app/views/shifts/show.html.erb
@@ -1,6 +1,6 @@
 <h2><%= @shift.shift_date.strftime("%Y-%m-%d") %> のシフト</h2>
 
-<table class="table table-bordered table-hover text-center">
+<table class="table table-bordered table-hover text-center" data-controller="shift-detail">
   <thead>
     <tr>
       <th class="bg-secondary text-white">スタッフ</th>
@@ -9,6 +9,7 @@
       <% (18..33).each do |h| %>
         <th class="bg-secondary text-white time-col"><%= "#{h % 24}:00" %></th>
       <% end %>
+      <th class="bg-secondary text-white">編集</th>
     </tr>
   </thead>
 
@@ -20,29 +21,58 @@
     <% grouped.each do |group_id, details| %>
       <!-- グループ行 -->
       <tr style="background-color: white; font-weight: bold;">
-        <td colspan="19"><%= Group.find_by(id: group_id)&.name || "未所属" %></td>
+        <td colspan="20"><%= Group.find_by(id: group_id)&.name || "未所属" %></td>
       </tr>
 
       <% details.each do |detail| %>
-        <tr>
+        <tr data-shift-detail-id="<%= detail.id %>">
           <!-- スタッフ名 -->
           <td class="text-start"><%= detail.staff.name %></td>
 
           <!-- 休憩室 -->
-          <td><%= detail.break_room&.name || "-" %></td>
+          <td>
+            <%= select_tag "break_room_id",
+                  options_from_collection_for_select(@break_rooms, :id, :name, detail.break_room_id),
+                  data: { action: "change->shift-detail#update",
+                          shift_detail_id: detail.id,
+                          field: "break_room_id" } %>
+          </td>
 
-          <!-- コメント（なければ - を表示） -->
+          <!-- コメント -->
           <td><%= detail.comment.presence || "-" %></td>
 
           <!-- 時間軸セル -->
           <% (18..33).each do |h| %>
             <% current_time = Time.zone.parse("#{detail.rest_start_time.to_date} #{h % 24}:00") %>
-            <% if (detail.rest_start_time...detail.rest_end_time).cover?(current_time) %>
-              <td class="bg-info"></td>
-            <% else %>
-              <td></td>
-            <% end %>
+            <% active = (detail.rest_start_time...detail.rest_end_time).cover?(current_time) %>
+            <td class="time-cell <%= 'bg-info' if active %>" data-hour="<%= h %>"></td>
           <% end %>
+
+          <!-- 編集用セレクト -->
+          <td>
+            <% start_h = detail.rest_start_time.hour + (detail.rest_start_time.to_date > @shift.shift_date ? 24 : 0) %>
+            <% end_h   = detail.rest_end_time.hour   + (detail.rest_end_time.to_date > @shift.shift_date ? 24 : 0) %>
+
+            開始:
+            <%= select_tag "rest_start_time",
+                  options_for_select(
+                    (18..33).map { |h| ["#{h % 24}:00", h] },
+                    start_h
+                  ),
+                  data: { action: "change->shift-detail#update",
+                          shift_detail_id: detail.id,
+                          field: "rest_start_time" } %><br>
+
+            終了:
+            <%= select_tag "rest_end_time",
+                  options_for_select(
+                    (18..33).map { |h| ["#{h % 24}:00", h] },
+                    end_h
+                  ),
+                  data: { action: "change->shift-detail#update",
+                          shift_detail_id: detail.id,
+                          field: "rest_end_time" } %>
+          </td>
         </tr>
       <% end %>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+
   devise_for :users
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
@@ -16,6 +17,8 @@ Rails.application.routes.draw do
   devise_scope :user do
     root to: "devise/sessions#new"
   end
+
+  resources :shift_details, only: [ :update ]
 
   resources :projects, only: [ :index, :new, :create, :edit, :update, :destroy ] do
     get "shift_top", to: "shifts#top"

--- a/test/controllers/shift_details_controller_test.rb
+++ b/test/controllers/shift_details_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class ShiftDetailsControllerTest < ActionDispatch::IntegrationTest
+  test "should get update" do
+    get shift_details_update_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
- view/shift/show.html.erbの手動編集画面の実装
- ShiftDetailsController
  - edit/updateアクションを作成し個別のシフト詳細（休憩開始/終了時間/休憩室）を編集できるようにした
- 編集画面
  - form_withを使用し休憩室、休憩開始・終了時間を選択できる
- バリデーションの追加
  - 休憩終了時間は休憩開始時間より後であることをチェック
  - エラー発生時はjsonレスポンスで返す形式
```
def rest_time_order
    return if rest_start_time.blank? || rest_end_time.blank?

    if rest_end_time <= rest_start_time
      errors.add(:rest_end_time, "は開始時間より後にしてください")
    end
  end
```

- 非同期処理の導入(stimulus)
  - stimulusコントローラを作成
  - 休憩時間開始と終了時間を修正すると時間軸の色が非同期で変更されるように
  - エラーがでた場合は時間軸の色は更新されないように設定

```
 fetch(`/shift_details/${id}`, {
      method: "PATCH",
      headers: {
        "Content-Type": "application/json",
        "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
      },
      body: JSON.stringify({ shift_detail: { [field]: value } })
    })
      .then(res => res.json())
      .then(data => {
        if (data.success) {
          // 成功 → 今回の値を新しい previousValue として保存
          select.dataset.previousValue = value
          this.refreshRow(data.detail)
        } else {
          // 失敗 → アラート表示 & 前の値に戻す
          alert("更新に失敗しました: " + data.errors.join(", "))

          // セレクトを前の状態に戻す
          select.value = select.dataset.previousValue

          // 色はDB側の状態（detail）でリフレッシュ
          if (data.detail) {
            this.refreshRow(data.detail)
          }
        }
      })
```
