### PR TITLE
手動編集後のバグ修正

### DIFF
--- a/app/controllers/shift_details_controller.rb
+++ b/app/controllers/shift_details_controller.rb
@@ -32,7 +32,10 @@ class ShiftDetailsController < ApplicationController
   end
 
   def shift_detail_params
-    params.require(:shift_detail).permit(:rest_start_time, :rest_end_time, :break_room_id)
+    permitted = params.require(:shift_detail).permit(:rest_start_time, :rest_end_time, :break_room_id, :group_id)
+    # 未所属は nil に統一する
+    permitted[:group_id] = nil if permitted[:group_id].blank? || permitted[:group_id].to_i == 0
+    permitted
   end
 
   # "26" → 翌日の 2:00 に変換

--- a/app/controllers/shifts_controller.rb
+++ b/app/controllers/shifts_controller.rb
@@ -76,7 +76,7 @@ class ShiftsController < ApplicationController
 
   def confirm
     @shift = @project.shifts.find(params[:id])
-    @shift_details = @shift.shift_details.includes(:staff, :break_rooom)
+    @shift_details = @shift.shift_details.includes(:staff, :break_room)
   end
 
   def finalize

--- a/app/javascript/controllers/shift_detail_controller.js
+++ b/app/javascript/controllers/shift_detail_controller.js
@@ -7,6 +7,11 @@ export default class extends Controller {
     const field = select.dataset.field
     const value = select.value
 
+    // 同じ行の hidden の group_id を拾う
+    const row = select.closest("tr[data-shift-detail-id]")
+    const groupInput = row.querySelector('input[name="group_id"]')
+    const groupId = groupInput ? groupInput.value : null
+
     // 前回の値を保存（必ず変更前を記録する）
     if (!select.dataset.previousValue) {
       select.dataset.previousValue = value
@@ -18,7 +23,12 @@ export default class extends Controller {
         "Content-Type": "application/json",
         "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content
       },
-      body: JSON.stringify({ shift_detail: { [field]: value } })
+      body: JSON.stringify({
+        shift_detail: {
+          [field]: value,
+          group_id: groupId   // ← 常に送る
+        }
+      })
     })
       .then(res => res.json())
       .then(data => {

--- a/app/services/shift_builder.rb
+++ b/app/services/shift_builder.rb
@@ -82,7 +82,8 @@ class ShiftBuilder
         end
         next unless staff # 全員割り当て済なら終了
 
-        group_id = @staff_groups[staff.id.to_s].presence || "ungrouped"
+        raw_gid = @staff_groups[staff.id.to_s]
+        group_id = raw_gid.present? ? raw_gid.to_i : nil
 
         shift.shift_details.create!(
             staff: staff,

--- a/app/views/shift_details/update.html.erb
+++ b/app/views/shift_details/update.html.erb
@@ -1,2 +1,0 @@
-<h1>ShiftDetails#update</h1>
-<p>Find me in app/views/shift_details/update.html.erb</p>

--- a/app/views/shifts/show.html.erb
+++ b/app/views/shifts/show.html.erb
@@ -72,6 +72,11 @@
                   data: { action: "change->shift-detail#update",
                           shift_detail_id: detail.id,
                           field: "rest_end_time" } %>
+
+            <!-- グループID hiddenで保持 -->
+            <%= hidden_field_tag "group_id",
+                  detail.group_id,
+                  data: { shift_detail_id: detail.id, field: "group_id" } %>
           </td>
         </tr>
       <% end %>


### PR DESCRIPTION
シフト手動編集後にconfirmページへ遷移後のバグを修正
- グループの並び順が変わっている(本来ならば無所属が一番下に配置される)
- グループに属していたメンバーが無所属に配置されてしまう

無所属のグループはgroup_id=nil を想定していたがto.i によりgroup_id=0 と変換されていたことが原因
